### PR TITLE
handle YARN_LOCK_OUT_OF_SYNC. closes #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,11 @@ const getTreeFromYarnLock = ({ yarnLock: yarnLockString, packageJSON, noDev }) =
 
   for (const [name, semver] of getAllDependencies(packageJSON, { noDev })) {
     if (/^link:/.test(semver)) continue
+    if (!yarnLock.object[`${name}@${semver}`]) {
+      const err = new Error('yarn.lock and package.json out of sync')
+      err.code = 'YARN_LOCK_OUT_OF_SYNC'
+      throw err
+    }
     const treeNode = new Node({
       name,
       version: yarnLock.object[`${name}@${semver}`].version,

--- a/test/index.js
+++ b/test/index.js
@@ -69,6 +69,24 @@ test('getTree.fromYarnLock', async t => {
       t.ok(tree.children.length > 0, 'found dependencies')
       t.ok(treeNoDev.children.length < tree.children.length, 'less dependencies')
     })
+
+    await t.test('out of sync with package.json', async t => {
+      const pkg = require('../package')
+      const err = new Error('yarn.lock and package.json out of sync')
+      err.code = 'YARN_LOCK_OUT_OF_SYNC'
+      t.throws(() => {
+        getTree.fromYarnLock({
+          yarnLock: fs.readFileSync(`${__dirname}/yarn.lock`, 'utf8'),
+          packageJSON: {
+            ...pkg,
+            dependencies: {
+              ...pkg.dependencies,
+              bloop: '1.0.0'
+            }
+          }
+        })
+      }, err)
+    })
   })
   await t.test('react', async t => {
     const tree = getTree.fromYarnLock({


### PR DESCRIPTION
When there's a `yarn.lock` but the `package.json` is newer, it might be that there are dependencies found in `package.json` but not in `yarn.lock`. This adds an error with code `YARN_LOCK_OUT_OF_SYNC`, so consumers can properly handle it.